### PR TITLE
Use catch all arguments

### DIFF
--- a/lib/rails_sql_prettifier.rb
+++ b/lib/rails_sql_prettifier.rb
@@ -20,9 +20,9 @@ module RailsSQLPrettifier
   end
 
   module PostgresAdapterNiceQL
-    def exec_query(sql, name = "SQL", binds = [], prepare: false)
+    def exec_query(sql, *args, **kwargs, &block)
       # replacing sql with prettified sql, thats all
-      super( Niceql::Prettifier.prettify_sql(sql, false), name, binds, prepare: prepare )
+      super( Niceql::Prettifier.prettify_sql(sql, false), *args, **kwargs, &block )
     end
   end
 


### PR DESCRIPTION
Fix for AR::Rel#load_async

```
(pry) output error: #<ArgumentError: unknown keyword: :async>
/usr/local/bundle/gems/rails_sql_prettifier-7.0.4/lib/rails_sql_prettifier.rb:23:in `exec_query'
/usr/local/bundle/gems/activerecord-7.0.4/lib/active_record/future_result.rb:127:in `exec_query'
/usr/local/bundle/gems/activerecord-7.0.4/lib/active_record/future_result.rb:133:in `exec_query'
/usr/local/bundle/gems/activerecord-7.0.4/lib/active_record/future_result.rb:119:in `execute_query'
/usr/local/bundle/gems/activerecord-7.0.4/lib/active_record/future_result.rb:108:in `block in execute_or_wait'
/usr/local/bundle/gems/activerecord-7.0.4/lib/active_record/future_result.rb:106:in `synchronize'
/usr/local/bundle/gems/activerecord-7.0.4/lib/active_record/future_result.rb:106:in `execute_or_wait'
/usr/local/bundle/gems/activerecord-7.0.4/lib/active_record/future_result.rb:82:in `result'
/usr/local/bundle/gems/activerecord-7.0.4/lib/active_record/relation.rb:912:in `block in exec_queries'
```