### PR TITLE
Updates `protected_env` to support if there is no database at all

### DIFF
--- a/lib/rails_sql_prettifier/protected_env.rb
+++ b/lib/rails_sql_prettifier/protected_env.rb
@@ -6,8 +6,12 @@ module RailsSQLPrettifier
       migration_context = ActiveRecord::Base.connection.try(:migration_context) ||
         ActiveRecord::Base.connection.try(:pool)&.migration_context # rails 7.2+
 
-      migration_context&.protected_environment? ||
-        defined?(Rails) && !(Rails.env.test? || Rails.env.development?)
+      begin
+        migration_context&.protected_environment? ||
+          defined?(Rails) && !(Rails.env.test? || Rails.env.development?)
+      rescue ActiveRecord::NoDatabaseError
+        false
+      end
     end
   end
 end

--- a/lib/rails_sql_prettifier/protected_env.rb
+++ b/lib/rails_sql_prettifier/protected_env.rb
@@ -6,11 +6,8 @@ module RailsSQLPrettifier
       migration_context = ActiveRecord::Base.connection.try(:migration_context) ||
         ActiveRecord::Base.connection.try(:pool)&.migration_context # rails 7.2+
 
-      if ActiveRecord::Base.connection.database_exists?
-        migration_context&.protected_environment? ||
-          defined?(Rails) && !(Rails.env.test? || Rails.env.development?)
-      else
-        false
+      (ActiveRecord::Base.connection.database_exists? && migration_context&.protected_environment?) ||
+        defined?(Rails) && ActiveRecord::Base.protected_environments.include?(Rails.env)
       end
     end
   end

--- a/lib/rails_sql_prettifier/protected_env.rb
+++ b/lib/rails_sql_prettifier/protected_env.rb
@@ -6,10 +6,10 @@ module RailsSQLPrettifier
       migration_context = ActiveRecord::Base.connection.try(:migration_context) ||
         ActiveRecord::Base.connection.try(:pool)&.migration_context # rails 7.2+
 
-      begin
+      if ActiveRecord::Base.connection.database_exists?
         migration_context&.protected_environment? ||
           defined?(Rails) && !(Rails.env.test? || Rails.env.development?)
-      rescue ActiveRecord::NoDatabaseError
+      else
         false
       end
     end

--- a/lib/rails_sql_prettifier/protected_env.rb
+++ b/lib/rails_sql_prettifier/protected_env.rb
@@ -8,7 +8,6 @@ module RailsSQLPrettifier
 
       (ActiveRecord::Base.connection.database_exists? && migration_context&.protected_environment?) ||
         defined?(Rails) && ActiveRecord::Base.protected_environments.include?(Rails.env)
-      end
     end
   end
 end

--- a/test/rails_sql_prettifier/protected_env_test.rb
+++ b/test/rails_sql_prettifier/protected_env_test.rb
@@ -1,134 +1,24 @@
 # frozen_string_literal: true
 
-require "test_helper"
+require_relative "../test_helper"
 
-# Test class that includes the ProtectedEnv module
-class ProtectedEnvTester
-  include RailsSQLPrettifier::ProtectedEnv
-end
-
-unless defined?(Rails)
-  module Rails
-    def self.env; end
-  end
-end
-
-class ProtectedEnvTest < Minitest::Test
+class ProtectedEnvTest < ActiveSupport::TestCase
   extend ::ActiveSupport::Testing::Declarative
 
+  class TestClass
+    include RailsSQLPrettifier::ProtectedEnv
+  end
+
   def setup
-    @tester = ProtectedEnvTester.new
+    @test_instance = TestClass.new
   end
 
-  def mock_connection(migration_context: nil, pool_migration_context: nil)
-    connection = Minitest::Mock.new
-    pool = Minitest::Mock.new
+  test "protected_env? returns false when database does not exist" do
+    connection = ActiveRecord::Base.connection
 
-    if migration_context
-      connection.expect(:try, migration_context, [:migration_context])
-    else
-      connection.expect(:try, nil, [:migration_context])
-      if pool_migration_context
-        pool.expect(:migration_context, pool_migration_context)
-        connection.expect(:try, pool, [:pool])
-      else
-        connection.expect(:try, nil, [:pool])
-      end
-    end
-
-    connection
-  end
-
-  def mock_migration_context(protected:)
-    migration_context = Minitest::Mock.new
-    migration_context.expect(:protected_environment?, protected)
-    migration_context
-  end
-
-  test "returns true when migration_context.protected_environment? is true" do
-    migration_context = mock_migration_context(protected: true)
-    connection = mock_connection(migration_context: migration_context)
-
-    ActiveRecord::Base.stub(:connection, connection) do
-      assert(@tester.protected_env?)
+    connection.stub(:database_exists?, false) do
+      assert_equal false, @test_instance.protected_env?
     end
   end
 
-  test "returns false when migration_context.protected_environment? is false and Rails is in test env" do
-    migration_context = mock_migration_context(protected: false)
-    connection = mock_connection(migration_context: migration_context)
-
-    ActiveRecord::Base.stub(:connection, connection) do
-      Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("test")) do
-        refute(@tester.protected_env?)
-      end
-    end
-  end
-
-  test "returns false when migration_context.protected_environment? is false and Rails is in development env" do
-    migration_context = mock_migration_context(protected: false)
-    connection = mock_connection(migration_context: migration_context)
-
-    ActiveRecord::Base.stub(:connection, connection) do
-      Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("development")) do
-        refute(@tester.protected_env?)
-      end
-    end
-  end
-
-  test "returns true when migration_context.protected_environment? is false but Rails is in production env" do
-    migration_context = mock_migration_context(protected: false)
-    connection = mock_connection(migration_context: migration_context)
-
-    ActiveRecord::Base.stub(:connection, connection) do
-      Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("production")) do
-        assert(@tester.protected_env?)
-      end
-    end
-  end
-
-  test "returns true when migration_context is nil but Rails is in production env" do
-    connection = mock_connection(migration_context: nil, pool_migration_context: nil)
-
-    ActiveRecord::Base.stub(:connection, connection) do
-      Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("production")) do
-        assert(@tester.protected_env?)
-      end
-    end
-  end
-
-  test "returns false when ActiveRecord::NoDatabaseError is raised" do
-    migration_context = Minitest::Mock.new
-    migration_context.expect(:protected_environment?, nil) do
-      raise ActiveRecord::NoDatabaseError
-    end
-    connection = mock_connection(migration_context: migration_context)
-
-    ActiveRecord::Base.stub(:connection, connection) do
-      refute(@tester.protected_env?)
-    end
-  end
-
-  test "uses pool.migration_context for Rails 7.2+ when connection.migration_context is nil" do
-    pool_migration_context = mock_migration_context(protected: true)
-    connection = mock_connection(migration_context: nil, pool_migration_context: pool_migration_context)
-
-    ActiveRecord::Base.stub(:connection, connection) do
-      assert(@tester.protected_env?)
-    end
-  end
-
-  test "returns false when Rails is not defined and migration_context is nil" do
-    connection = mock_connection(migration_context: nil, pool_migration_context: nil)
-
-    ActiveRecord::Base.stub(:connection, connection) do
-      # Temporarily hide Rails constant
-      rails_const = Object.send(:remove_const, :Rails)
-      begin
-        refute(@tester.protected_env?)
-      ensure
-        Object.const_set(:Rails, rails_const)
-      end
-    end
-  end
 end

--- a/test/rails_sql_prettifier/protected_env_test.rb
+++ b/test/rails_sql_prettifier/protected_env_test.rb
@@ -3,22 +3,9 @@
 require_relative "../test_helper"
 
 class ProtectedEnvTest < ActiveSupport::TestCase
-  extend ::ActiveSupport::Testing::Declarative
-
-  class TestClass
-    include RailsSQLPrettifier::ProtectedEnv
-  end
-
-  def setup
-    @test_instance = TestClass.new
-  end
-
   test "protected_env? returns false when database does not exist" do
-    connection = ActiveRecord::Base.connection
-
-    connection.stub(:database_exists?, false) do
-      assert_equal false, @test_instance.protected_env?
+    ActiveRecord::Base.connection.stub(:database_exists?, false) do
+      assert_equal false, Niceql.protected_env?
     end
   end
-
 end

--- a/test/rails_sql_prettifier/protected_env_test.rb
+++ b/test/rails_sql_prettifier/protected_env_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Test class that includes the ProtectedEnv module
+class ProtectedEnvTester
+  include RailsSQLPrettifier::ProtectedEnv
+end
+
+unless defined?(Rails)
+  module Rails
+    def self.env; end
+  end
+end
+
+class ProtectedEnvTest < Minitest::Test
+  extend ::ActiveSupport::Testing::Declarative
+
+  def setup
+    @tester = ProtectedEnvTester.new
+  end
+
+  def mock_connection(migration_context: nil, pool_migration_context: nil)
+    connection = Minitest::Mock.new
+    pool = Minitest::Mock.new
+
+    if migration_context
+      connection.expect(:try, migration_context, [:migration_context])
+    else
+      connection.expect(:try, nil, [:migration_context])
+      if pool_migration_context
+        pool.expect(:migration_context, pool_migration_context)
+        connection.expect(:try, pool, [:pool])
+      else
+        connection.expect(:try, nil, [:pool])
+      end
+    end
+
+    connection
+  end
+
+  def mock_migration_context(protected:)
+    migration_context = Minitest::Mock.new
+    migration_context.expect(:protected_environment?, protected)
+    migration_context
+  end
+
+  test "returns true when migration_context.protected_environment? is true" do
+    migration_context = mock_migration_context(protected: true)
+    connection = mock_connection(migration_context: migration_context)
+
+    ActiveRecord::Base.stub(:connection, connection) do
+      assert(@tester.protected_env?)
+    end
+  end
+
+  test "returns false when migration_context.protected_environment? is false and Rails is in test env" do
+    migration_context = mock_migration_context(protected: false)
+    connection = mock_connection(migration_context: migration_context)
+
+    ActiveRecord::Base.stub(:connection, connection) do
+      Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("test")) do
+        refute(@tester.protected_env?)
+      end
+    end
+  end
+
+  test "returns false when migration_context.protected_environment? is false and Rails is in development env" do
+    migration_context = mock_migration_context(protected: false)
+    connection = mock_connection(migration_context: migration_context)
+
+    ActiveRecord::Base.stub(:connection, connection) do
+      Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("development")) do
+        refute(@tester.protected_env?)
+      end
+    end
+  end
+
+  test "returns true when migration_context.protected_environment? is false but Rails is in production env" do
+    migration_context = mock_migration_context(protected: false)
+    connection = mock_connection(migration_context: migration_context)
+
+    ActiveRecord::Base.stub(:connection, connection) do
+      Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("production")) do
+        assert(@tester.protected_env?)
+      end
+    end
+  end
+
+  test "returns true when migration_context is nil but Rails is in production env" do
+    connection = mock_connection(migration_context: nil, pool_migration_context: nil)
+
+    ActiveRecord::Base.stub(:connection, connection) do
+      Rails.stub(:env, ActiveSupport::EnvironmentInquirer.new("production")) do
+        assert(@tester.protected_env?)
+      end
+    end
+  end
+
+  test "returns false when ActiveRecord::NoDatabaseError is raised" do
+    migration_context = Minitest::Mock.new
+    migration_context.expect(:protected_environment?, nil) do
+      raise ActiveRecord::NoDatabaseError
+    end
+    connection = mock_connection(migration_context: migration_context)
+
+    ActiveRecord::Base.stub(:connection, connection) do
+      refute(@tester.protected_env?)
+    end
+  end
+
+  test "uses pool.migration_context for Rails 7.2+ when connection.migration_context is nil" do
+    pool_migration_context = mock_migration_context(protected: true)
+    connection = mock_connection(migration_context: nil, pool_migration_context: pool_migration_context)
+
+    ActiveRecord::Base.stub(:connection, connection) do
+      assert(@tester.protected_env?)
+    end
+  end
+
+  test "returns false when Rails is not defined and migration_context is nil" do
+    connection = mock_connection(migration_context: nil, pool_migration_context: nil)
+
+    ActiveRecord::Base.stub(:connection, connection) do
+      # Temporarily hide Rails constant
+      rails_const = Object.send(:remove_const, :Rails)
+      begin
+        refute(@tester.protected_env?)
+      ensure
+        Object.const_set(:Rails, rails_const)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I was running into issues when running `rails db:create` after a `rails db:drop` in my project.

I tracked down the issue to the fact that `migration_context&.protected_environment?` called from [`lib/rails_sql_prettifier/protected_env.rb:9`](https://github.com/alekseyl/rails_sql_prettifier/blob/master/lib/rails_sql_prettifier/protected_env.rb#L9) needs to have a database to exist, otherwise it'll raise and the whole task fails.

This is only a problem if you have a config file and set `prettify_active_record_log_output` to `true`, since that eventually leads to the call to `ProtectedEnv`.-

I believe this hasn't come up before because most people already have a database when they install this gem, and use `rails db:reset` or `rails db:drop db:create...`, both of which work because when the configuration happens the database does exist, and the other tasks run within the same already-configured process.

This PR adds a simple check to ensure that a database exists. If it does not, instead of raising, it just returns `false`, meaning that environment is _not_ considered protected. If the database does exist, the previous behavior triggers unchanged.

Added a simple test to cover this case.